### PR TITLE
Bbontrager89/add-polar-tests

### DIFF
--- a/src/main/java/frc/robot/subsystems/PolarSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PolarSubsystem.java
@@ -15,7 +15,7 @@ import frc.robot.Constants;
 
 import static frc.robot.Constants.FieldConstants.*;
 
-public class PolarSubsystem extends SubsystemBase {
+public class PolarSubsystem extends SubsystemBase implements AutoCloseable {
 
   public final CommandSwerveDrivetrain driveTrain;
 
@@ -402,4 +402,8 @@ public class PolarSubsystem extends SubsystemBase {
       return rpm;
     }
   }
+
+public void close() {
+    driveTrain.close();
+}
 }

--- a/src/test/java/frc/robot/subsystems/PolarSubsystemTest.java
+++ b/src/test/java/frc/robot/subsystems/PolarSubsystemTest.java
@@ -3,6 +3,7 @@ package frc.robot.subsystems;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -44,6 +45,18 @@ class PolarSubsystemTest {
         try (MockedStatic<DriverStation> ds = mockStatic(DriverStation.class)) {
             ds.when(DriverStation::getAlliance).thenReturn(Optional.of(Alliance.Blue));
             polarSubsystem = new PolarSubsystem(mockDrivetrain);
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (polarSubsystem != null) {
+            try {
+                polarSubsystem.close();
+            } catch (Exception e) {
+                // Ignore errors during standard close
+            }
+            polarSubsystem = null;
         }
     }
 


### PR DESCRIPTION
Reverts 760462c72d7b605cbf4703ca68986247cdf95b6d, effectively adding in broken tests. 

Fixes broken shooter and intake tests (due to CAN ID conflicts) by implementing teardown function. 

Effectively reopens #64 for a fix.
Technically reopens #19. 